### PR TITLE
Fix null handling for rule factories

### DIFF
--- a/src/main/java/dev/codetoreason/patterns/tactical/rule/Rules.java
+++ b/src/main/java/dev/codetoreason/patterns/tactical/rule/Rules.java
@@ -106,6 +106,9 @@ public class Rules<T> {
      * @return a {@link RulesBuilder} instance
      */
     public static <T> RulesBuilder<T> when(RuleFactory<T> ruleFactory) {
+        if (ruleFactory == null) {
+            throw new IllegalArgumentException("Rule factory must be non-null");
+        }
         return new RulesBuilder<>(ruleFactory.create());
     }
 
@@ -170,6 +173,9 @@ public class Rules<T> {
          * @return this builder instance
          */
         public RulesBuilder<T> and(RuleFactory<T> ruleFactory) {
+            if (ruleFactory == null) {
+                throw new IllegalArgumentException("Rule factory must be non-null");
+            }
             return and(ruleFactory.create());
         }
 


### PR DESCRIPTION
## Summary
- ensure `Rules.when` validates provided RuleFactory
- guard `Rules.RulesBuilder.and` against null RuleFactory

## Testing
- `mvn -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68475b41e444832e9bc8eade5060804a