### PR TITLE
Fix javadoc wording

### DIFF
--- a/src/main/java/dev/codetoreason/patterns/tactical/infra/repository/InMemoryEntityRepository.java
+++ b/src/main/java/dev/codetoreason/patterns/tactical/infra/repository/InMemoryEntityRepository.java
@@ -36,7 +36,7 @@ public abstract class InMemoryEntityRepository<E extends Entity<ID>, ID> impleme
      * Attempts to find an entity by its identifier.
      *
      * @param id the identifier of the entity
-     * @return an {@link Optional} containing the entity if found, or empty if not
+     * @return an {@link Optional} containing the entity if found, or empty if not found.
      */
     @Override
     public Optional<E> findById(ID id) {


### PR DESCRIPTION
## Summary
- clarify `findById` javadoc in `InMemoryEntityRepository`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f9146c4c832e821df0bfbcd22b8f