### PR TITLE
Clarify Rule builder failure reason message

### DIFF
--- a/src/main/java/dev/codetoreason/patterns/tactical/rule/Rule.java
+++ b/src/main/java/dev/codetoreason/patterns/tactical/rule/Rule.java
@@ -90,7 +90,7 @@ public class Rule<T> {
          */
         public Rule<T> orElse(String failureReason) {
             if (failureReason == null || failureReason.isBlank()) {
-                throw new IllegalArgumentException("Failure reason must be non-null and non-blank.");
+                throw new IllegalArgumentException("Failure reason must be non-null and non-blank");
             }
             return orElse(_ -> failureReason);
         }

--- a/src/main/java/dev/codetoreason/patterns/tactical/rule/Rule.java
+++ b/src/main/java/dev/codetoreason/patterns/tactical/rule/Rule.java
@@ -90,7 +90,7 @@ public class Rule<T> {
          */
         public Rule<T> orElse(String failureReason) {
             if (failureReason == null || failureReason.isBlank()) {
-                throw new IllegalArgumentException("FailureReason function must be non-null and non-blank");
+                throw new IllegalArgumentException("Failure reason must be non-null and non-blank.");
             }
             return orElse(_ -> failureReason);
         }


### PR DESCRIPTION
## Summary
- update the exception thrown by `Rule.RuleBuilder.orElse(String)` to clarify the failure reason requirement

## Testing
- `./mvnw -q test` *(fails: unable to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6847fd6935c4832eaf298a778c46a188